### PR TITLE
Fire a custom action when authenticating

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -390,6 +390,9 @@ class Application_Passwords {
 				$item['last_ip']   = $_SERVER['REMOTE_ADDR'];
 				$hashed_passwords[ $key ] = $item;
 				update_user_meta( $user->ID, self::USERMETA_KEY_APPLICATION_PASSWORDS, $hashed_passwords );
+
+				do_action( 'application_password_did_authenticate', $user, $item );
+
 				return $user;
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -34,11 +34,18 @@ Use Application Passwords to authenticate users without providing their password
 
 = Two Factor Support =
 
-Application Passwords can be used together with the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) as long as you disable the extra protection added by the Two Factor plugin which disables API requests with password authentication _for users with Two Factor enabled_.
+Application Passwords can be used together with the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) as long as you bypass the API acccess restrictions added by the Two Factor plugin. Those protections disable API requests with password authentication _for users with Two Factor enabled_.
 
-Use the `two_factor_user_api_login_enable` filter to allow API requests with password-based authentication header for all users:
+Use the `two_factor_user_api_login_enable` filter to allow API requests authenticated using an application passwords:
 
-    add_filter( 'two_factor_user_api_login_enable', '__return_true' );
+    add_filter( 'two_factor_user_api_login_enable', function( $enable ) {
+        // Allow API login when using an application password even with 2fa enabled.
+        if ( did_action( 'application_password_did_authenticate' ) ) {
+            return true;
+        }
+
+        return $enable;
+    } );
 
 This is not required if the user associated with the application password doesn't have any of the Two Factor methods enabled.
 


### PR DESCRIPTION
This will provide a signal for other plugins like Two Factor that the user successfully authenticated via an application password and allow them to take further action.

For example, for users of the Two Factor (or other auth) plugin, you could hook in to the new filter and allow the login while restricting others:

```
add_filter( 'two_factor_user_api_login_enable', function( $enable ) {
    // The request uses an Application Password. Override any API login restrictions in place.
    if ( did_action( 'application_password_did_authenticate' ) ) {
        return true;
    }

    return $enable;
}
```

The example there is a bit simplistic (doesn't validate user ID, for example) but hopefully gets the point across.