### PR TITLE
Support WPGraphQL

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -336,7 +336,8 @@ class Application_Passwords {
 	 */
 	public static function is_api_request() {
 		// Process the authentication only after the APIs have been initialized.
-		return ( ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) );
+		$WPGRAPHQL_REQUEST = function_exists('is_graphql_http_request') ? is_graphql_http_request() : false;
+		return ( ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || $WPGRAPHQL_REQUEST );
 	}
 
 	/**


### PR DESCRIPTION
Hi, would you be willing to support [WPGraphQL](https://www.wpgraphql.com/)?

[This line](https://plugins.trac.wordpress.org/browser/application-passwords/trunk/class.application-passwords.php#L339) only allows XML RPC and REST. It therefore actively blocks WPGraphQL requests.

It works really well once you get past that check as WPGraphQL relies on WP internals for auth.

Here is a try at a PR, let me know if you want any changes to it and I'll be glad to get it done so it can be merged and released 👍 