### PR TITLE
Add: confirmation before revoking password

### DIFF
--- a/application-passwords.js
+++ b/application-passwords.js
@@ -80,7 +80,7 @@
 	$appPassTbody.on( 'click', '.delete', function( e ) {
 		e.preventDefault();
 
-		if ( ! confirm( appPass.revoke_password ) ) {
+		if ( ! confirm( appPass.text.revoke_password ) ) {
 			return;
 		}
 
@@ -106,7 +106,7 @@
 	$removeAllBtn.on( 'click', function( e ) {
 		e.preventDefault();
 
-		if ( ! confirm( appPass.revoke_all_passwords ) ) {
+		if ( ! confirm( appPass.text.revoke_all_passwords ) ) {
 			return;
 		}
 

--- a/application-passwords.js
+++ b/application-passwords.js
@@ -1,4 +1,5 @@
 /* global appPass, wp */
+/* eslint-disable no-alert */
 ( function( $, appPass ) {
 	var $appPassSection = $( '#application-passwords-section' ),
 		$newAppPassForm = $appPassSection.find( '.create-application-password' ),
@@ -78,6 +79,11 @@
 
 	$appPassTbody.on( 'click', '.delete', function( e ) {
 		e.preventDefault();
+
+		if ( ! confirm( appPass.revoke_password ) ) {
+			return;
+		}
+
 		var $tr = $( e.target ).closest( 'tr' ),
 			slug = $tr.data( 'slug' );
 
@@ -99,6 +105,10 @@
 
 	$removeAllBtn.on( 'click', function( e ) {
 		e.preventDefault();
+
+		if ( ! confirm( appPass.revoke_all_passwords ) ) {
+			return;
+		}
 
 		$.ajax( {
 			url: appPass.root + appPass.namespace + '/application-passwords/' + appPass.user_id,

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -568,11 +568,13 @@ class Application_Passwords {
 			'application-passwords-js',
 			'appPass',
 			array(
-				'root'      => esc_url_raw( rest_url() ),
-				'namespace' => '2fa/v1',
-				'nonce'     => wp_create_nonce( 'wp_rest' ),
-				'user_id'   => $user->ID,
-				'text'      => array(
+				'root'                 => esc_url_raw( rest_url() ),
+				'namespace'            => '2fa/v1',
+				'nonce'                => wp_create_nonce( 'wp_rest' ),
+				'user_id'              => $user->ID,
+				'revoke_password'      => esc_attr__( 'Are you sure you want to revoke this password? This action cannot be undone.' ),
+				'revoke_all_passwords' => esc_attr__( 'Are you sure you want to revoke all passwords? This action cannot be undone.' ),
+				'text'                 => array(
 					'no_credentials' => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
 				),
 			)

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -568,14 +568,14 @@ class Application_Passwords {
 			'application-passwords-js',
 			'appPass',
 			array(
-				'root'                 => esc_url_raw( rest_url() ),
-				'namespace'            => '2fa/v1',
-				'nonce'                => wp_create_nonce( 'wp_rest' ),
-				'user_id'              => $user->ID,
-				'revoke_password'      => esc_attr__( 'Are you sure you want to revoke this password? This action cannot be undone.' ),
-				'revoke_all_passwords' => esc_attr__( 'Are you sure you want to revoke all passwords? This action cannot be undone.' ),
-				'text'                 => array(
-					'no_credentials' => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
+				'root'      => esc_url_raw( rest_url() ),
+				'namespace' => '2fa/v1',
+				'nonce'     => wp_create_nonce( 'wp_rest' ),
+				'user_id'   => $user->ID,
+				'text'      => array(
+					'no_credentials'       => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
+					'revoke_password'      => esc_attr__( 'Are you sure you want to revoke this password? This action cannot be undone.' ),
+					'revoke_all_passwords' => esc_attr__( 'Are you sure you want to revoke all passwords? This action cannot be undone.' ),
 				),
 			)
 		);


### PR DESCRIPTION
This PR adds a confirmation box when users click on revoke password buttons. This is the replacement for #23.
Resolve #17.